### PR TITLE
Golang

### DIFF
--- a/asciicast/recorder.go
+++ b/asciicast/recorder.go
@@ -1,8 +1,18 @@
 package asciicast
 
 import (
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
 	"github.com/asciinema/asciinema/terminal"
 	"github.com/asciinema/asciinema/util"
+)
+
+const (
+	optimalCols = 120
+	optimalRows = 30
 )
 
 type Recorder interface {
@@ -17,17 +27,49 @@ func NewRecorder() Recorder {
 	return &AsciicastRecorder{Terminal: terminal.NewTerminal()}
 }
 
+func (r *AsciicastRecorder) checkTerminalSize() chan<- bool {
+	rows, cols, _ := r.Terminal.Size()
+	doneChan := make(chan bool)
+	optimalSize := fmt.Sprintf("%s%dx%d%s", "\x1b[0m\x1b[32m", optimalCols, optimalRows, "\x1b[0m\x1b[33m")
+	go func() {
+		winch := make(chan os.Signal, 1)
+		signal.Notify(winch, syscall.SIGWINCH)
+
+		defer signal.Stop(winch)
+		defer close(winch)
+		defer close(doneChan)
+
+		for {
+			select {
+			case <-winch:
+				newRows, newCols, _ := r.Terminal.Size()
+				if cols != newCols || rows != newRows {
+					cols, rows = newCols, newRows
+					currentSize := fmt.Sprintf("%dx%d", cols, rows)
+					if cols == optimalCols && rows == optimalRows {
+						currentSize = fmt.Sprintf("%s%dx%d%s", "\x1b[0m\x1b[32m", cols, rows, "\x1b[0m\x1b[33m")
+					}
+					util.ReplaceWarningf("Current terminal size is %s. Optimal is %s.", currentSize, optimalSize)
+				}
+			case <-doneChan:
+				return
+			}
+		}
+	}()
+	return doneChan
+}
+
 func (r *AsciicastRecorder) Record(path, command, title string, maxWait float64, assumeYes bool, env map[string]string) error {
 	// TODO: touch savePath to ensure writing is possible
 
 	rows, cols, _ := r.Terminal.Size()
-	if rows > 30 || cols > 120 {
-		util.Warningf("Current terminal size is %vx%v.", cols, rows)
-		util.Warningf("It may be too big to be properly replayed on smaller screens.")
-
+	if rows != optimalRows || cols != optimalCols {
 		if !assumeYes {
+			doneChan := r.checkTerminalSize()
+			util.Warningf("Current terminal size is %vx%v. Optimal is %vx%v", cols, rows, optimalCols, optimalRows)
 			util.Warningf("You can now resize it. Press <Enter> to start recording.")
 			util.ReadLine()
+			doneChan <- true
 		}
 	}
 

--- a/asciicast/recorder.go
+++ b/asciicast/recorder.go
@@ -11,8 +11,8 @@ import (
 )
 
 const (
-	optimalCols = 120
-	optimalRows = 30
+	warnCols = 120
+	warnRows = 30
 )
 
 type Recorder interface {
@@ -30,7 +30,6 @@ func NewRecorder() Recorder {
 func (r *AsciicastRecorder) checkTerminalSize() chan<- bool {
 	rows, cols, _ := r.Terminal.Size()
 	doneChan := make(chan bool)
-	optimalSize := fmt.Sprintf("%s%dx%d%s", "\x1b[0m\x1b[32m", optimalCols, optimalRows, "\x1b[0m\x1b[33m")
 	go func() {
 		winch := make(chan os.Signal, 1)
 		signal.Notify(winch, syscall.SIGWINCH)
@@ -46,10 +45,7 @@ func (r *AsciicastRecorder) checkTerminalSize() chan<- bool {
 				if cols != newCols || rows != newRows {
 					cols, rows = newCols, newRows
 					currentSize := fmt.Sprintf("%dx%d", cols, rows)
-					if cols == optimalCols && rows == optimalRows {
-						currentSize = fmt.Sprintf("%s%dx%d%s", "\x1b[0m\x1b[32m", cols, rows, "\x1b[0m\x1b[33m")
-					}
-					util.ReplaceWarningf("Current terminal size is %s. Optimal is %s.", currentSize, optimalSize)
+					util.ReplaceWarningf("Current terminal size is %s.", currentSize)
 				}
 			case <-doneChan:
 				return
@@ -63,10 +59,11 @@ func (r *AsciicastRecorder) Record(path, command, title string, maxWait float64,
 	// TODO: touch savePath to ensure writing is possible
 
 	rows, cols, _ := r.Terminal.Size()
-	if rows != optimalRows || cols != optimalCols {
+	if rows > warnRows || cols > warnCols {
 		if !assumeYes {
 			doneChan := r.checkTerminalSize()
-			util.Warningf("Current terminal size is %vx%v. Optimal is %vx%v", cols, rows, optimalCols, optimalRows)
+			util.Warningf("Current terminal size is %vx%v.", cols, rows)
+			util.Warningf("It may be too big to be properly replayed on smaller screens.")
 			util.Warningf("You can now resize it. Press <Enter> to start recording.")
 			util.ReadLine()
 			doneChan <- true

--- a/util/echo.go
+++ b/util/echo.go
@@ -17,6 +17,10 @@ func Printf(s string, args ...interface{}) {
 	fmt.Fprintf(loggerOutput, "\x1b[32m~ %v\x1b[0m\n", fmt.Sprintf(s, args...))
 }
 
+func ReplaceWarningf(s string, args ...interface{}) {
+	fmt.Fprintf(loggerOutput, "\r\x1b[33m~ %v\x1b[0m", fmt.Sprintf(s, args...))
+}
+
 func Warningf(s string, args ...interface{}) {
 	fmt.Fprintf(loggerOutput, "\x1b[33m~ %v\x1b[0m\n", fmt.Sprintf(s, args...))
 }


### PR DESCRIPTION
# asciicast file format (version 1)

asciicast file is JSON file containing meta-data like duration or title of the
recording, and the actual content printed to terminal's stdout during
recording.

Version 1 of the format was used by the asciinema recorder versions 1.0 up to 1.4.

## Attributes

Every asciicast includes the following set of attributes:

* `version` - set to 1,
* `width` - terminal width (number of columns),
* `height` - terminal height (number of rows),
* `duration` - total duration of asciicast as floating point number,
* `command` - command that was recorded, as given via `-c` option to `rec`,
* `title` - title of the asciicast, as given via `-t` option to `rec`,
* `env` - map of environment variables useful for debugging playback problems,
* `stdout` - array of "frames", see below.

### Frame

Frame represents an event of printing new data to terminal's stdout. It is a 2
element array containing **delay** and **data**.

**Delay** is the number of seconds that elapsed since the previous frame (or
since the beginning of the recording in case of the 1st frame) represented as
a floating point number, with microsecond precision.

**Data** is a string containing the data that was printed to a terminal in a
given frame. It has to be valid, UTF-8 encoded JSON string as described in
[JSON RFC section 2.5](http://www.ietf.org/rfc/rfc4627.txt), with all
non-printable Unicode codepoints encoded as `\uXXXX`.

For example, frame `[5.4321, "foo\rbar\u0007..."]` means there was 5 seconds of
inactivity between previous printing and printing of `foo\rbar\u0007...`.

## Example asciicast

A very short asciicast may look like this:

    {
      "version": 1,
      "width": 80,
      "height": 24,
      "duration": 1.515658,
      "command": "/bin/zsh",
      "title": "",
      "env": {
        "TERM": "xterm-256color",
        "SHELL": "/bin/zsh"
      },
      "stdout": [
        [
          0.248848,
          "\u001b[1;31mHello \u001b[32mWorld!\u001b[0m\n"
        ],
        [
          1.001376,
          "I am \rThis is on the next line."
        ]
      ]
    }
